### PR TITLE
works with spatial data

### DIFF
--- a/man/ecocrop.Rd
+++ b/man/ecocrop.Rd
@@ -44,6 +44,14 @@ ecocrop('potato', 5:16, 15:26, runif(12)*100)
 getCrop('Acacia brachystachya Benth.')
 crop <- getCrop('Hot pepper')
 ecocrop(crop, 5:16, 15:26, rainfed=FALSE)
+
+# with spatial data
+tmin = tavg = prec = brick(nrow=1, ncol=1)
+tmin <- setValues(tmin, t(matrix(5:16)))
+tavg <- tmin + 5
+prec <- setValues(prec, t(matrix(15:26)))
+crop <- getCrop('Hot pepper')
+ecocrop(crop, tmin, prec, rainfed = FALSE)
 }
 
 \keyword{spatial}


### PR DESCRIPTION
`ecocrop()` now works with the spatial data without the previous errors, returns the suitability. `div` argument is removed from `.ecoSpat()`. It could be included in the `getCrop()` if needed. It's much easier to modify the crop parameter than to change the temperature raster stack.  